### PR TITLE
theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 [![codecov](https://codecov.io/gh/mylesj/docsify-nomnoml/branch/main/graph/badge.svg?token=N2HV4ZPB4P)](https://codecov.io/gh/mylesj/docsify-nomnoml)
 [![nomnoml](https://img.shields.io/badge/www-nomnoml-%23fdf6e3)](https://nomnoml.com)
 [![docsify](https://img.shields.io/badge/www-docsify-%2342b983)](https://docsify.js.org)
+[![themeable](https://img.shields.io/badge/www-themeable-%230a87da)](https://jhildenbiddle.github.io/docsify-themeable/)
 
 ## Install
 
 Add the following scripts to the docsify `index.html` file - note that the
-peer-dependencies, `nomnoml` and `graphre` should be loaded before the plugin.
+peer-dependencies, `nomnoml` and `graphre` must be loaded before the plugin.
 
 ```html
 <script src="//cdn.jsdelivr.net/npm/graphre@0.1/dist/graphre.js"></script>
@@ -53,9 +54,33 @@ Some optional attributes may be specified after the render instruction:
 ```
 ````
 
+## Theming
+
+By default the plugin will try to match the `stroke` and `fill` colors of the rendered SVG
+to the current theme. This may be overridden by explicity declaring custom CSS rules.
+
+```css
+:root {
+	--nomnoml-svg-stroke: <color>;
+	--nomnoml-svg-fill-1: <color>;
+	--nomnoml-svg-fill-2: <color>;
+}
+```
+
+Alternatively, the theming can be completely disabled by setting:
+
+```js
+window.$docsify = {
+	// ...
+	nomnoml: {
+		autotheme: false,
+	},
+}
+```
+
 ## Directives
 
-While directives may ordinarily be specified in nomnoml code, it may be preferable to define
+While directives may ordinarily be specified in nomnoml syntax, it may be preferable to define
 some of them globally such that they are consistently applied throughout a docsify instance.
 For example:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+    status:
+        project:
+            default:
+                target: 95%
+                threshold: 1%

--- a/src/main-browser.test.ts
+++ b/src/main-browser.test.ts
@@ -115,6 +115,12 @@ describe('when peer dependencies are met', () => {
 		expect(pluginCreator).toHaveBeenCalledWith({
 			nomnoml: dependency,
 			config: pluginConfig,
+			autotheme: expect.arrayContaining([
+				expect.objectContaining({
+					foregroundColor: expect.any(String),
+					backgroundColor: expect.any(String),
+				}),
+			]),
 		})
 	})
 })

--- a/src/main-browser.ts
+++ b/src/main-browser.ts
@@ -23,10 +23,25 @@ if (isMetDependencies) {
 	if (!isObject(window.$docsify.nomnoml)) {
 		window.$docsify.nomnoml = {}
 	}
+
+	const [rootStyle, bodyStyle] = [':root', 'body'].map((selector) =>
+		window.getComputedStyle(<Element>document.querySelector(selector))
+	)
+
 	window.$docsify.plugins.push(
 		createPlugin({
 			nomnoml: window.nomnoml,
 			config: window.$docsify.nomnoml,
+			autotheme: [
+				{
+					foregroundColor: rootStyle.color,
+					backgroundColor: rootStyle.backgroundColor,
+				},
+				{
+					foregroundColor: bodyStyle.color,
+					backgroundColor: bodyStyle.backgroundColor,
+				},
+			],
 		})
 	)
 }

--- a/src/main-node.ts
+++ b/src/main-node.ts
@@ -1,9 +1,9 @@
 import nomnoml from 'nomnoml'
 
-import { NomnomlConfig } from './shared/types'
+import { UserConfig } from './shared/types'
 import { createPlugin as createPluginInternal } from './shared/plugin'
 
-export const createPlugin = (config: NomnomlConfig) =>
+export const createPlugin = (config: UserConfig) =>
 	createPluginInternal({ nomnoml, config })
 
 /*

--- a/src/shared/svg.test.ts
+++ b/src/shared/svg.test.ts
@@ -1,8 +1,8 @@
-import { Nomnoml, NomnomlConfig } from './types'
+import { Nomnoml, UserConfig } from './types'
 import { createSvgCreator } from './svg'
 
 let nomnoml: Nomnoml
-let config: NomnomlConfig
+let config: UserConfig
 beforeEach(() => {
 	;(nomnoml = {} as Nomnoml), (config = {})
 })
@@ -102,6 +102,34 @@ describe('when valid input is rendered by nomnoml', () => {
 		const createSvg = createSvgCreator({ nomnoml, config })
 		const expected =
 			'<svg role="img" aria-label="title" class="nomnoml-svg"><title>title</title>#foo: 111\n#bar: 222\n#baz: 333\n[a]->[b]</svg>'
+		const actual = createSvg(
+			'#baz: 333\n[a]->[b]',
+			'noml render title=title'
+		)
+		expect(actual).toBe(expected)
+	})
+
+	it('should concatenate theme directives if resolved successfully', () => {
+		nomnoml.renderSvg = (x) => `<svg>${x}</svg>`
+		config.directives = {
+			foo: 111,
+			bar: '222',
+		}
+		const autotheme = [
+			{
+				foregroundColor: '#ffffff',
+				backgroundColor: '#000000',
+			},
+		]
+		const createSvg = createSvgCreator({ nomnoml, config, autotheme })
+		const expected = [
+			'<svg role="img" aria-label="title" class="nomnoml-svg"><title>title</title>#stroke: var(--nomnoml-svg-stroke, var(--theme-color, #ffffff))',
+			'#fill: var(--nomnoml-svg-fill-1, var(--mono-shade2, #000000)); var(--nomnoml-svg-fill-2, var(--mono-shade3, #000000))',
+			'#foo: 111',
+			'#bar: 222',
+			'#baz: 333',
+			'[a]->[b]</svg>',
+		].join('\n')
 		const actual = createSvg(
 			'#baz: 333\n[a]->[b]',
 			'noml render title=title'

--- a/src/shared/svg.ts
+++ b/src/shared/svg.ts
@@ -5,6 +5,7 @@ import {
 	stringifyDirectives,
 	encodeHtmlReserved,
 	isValidCssClass,
+	getThemeStyles,
 	isObject,
 } from './util'
 
@@ -14,12 +15,20 @@ const USER_ATTRIBUTES: Attribute[] = ['title', 'class', 'width', 'height']
 const RE_MATCH_SVG_TAG = /(.*?)(<svg)(.*?)(\/?>)/i
 
 export const createSvgCreator =
-	({ nomnoml, config }: Dependencies) =>
+	({ nomnoml, config, autotheme }: Dependencies) =>
 	(nomlnomlStr: string, attributes: string): string | Error => {
-		const directives = isObject(config.directives)
+		const userDirectives = isObject(config.directives)
 			? `${stringifyDirectives(<Directives>config.directives)}\n`
 			: ''
 
+		let themeDirectives = ''
+		if (autotheme && config.autotheme !== false) {
+			themeDirectives = stringifyDirectives(getThemeStyles(autotheme))
+		}
+
+		const directives = [themeDirectives, userDirectives]
+			.filter(Boolean)
+			.join('\n')
 		const svg = nomnoml.renderSvg(`${directives}${nomlnomlStr}`)
 		const match = svg.match(RE_MATCH_SVG_TAG)
 

--- a/src/shared/types/types.global.d.ts
+++ b/src/shared/types/types.global.d.ts
@@ -2,7 +2,7 @@ declare interface Window {
 	nomnoml?: Nomnoml
 	graphre?: Graphre
 	$docsify?: {
-		nomnoml?: NomnomlConfig
+		nomnoml?: UserConfig
 		plugins?: Function[]
 	}
 }

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -5,17 +5,24 @@ export type Attribute = 'title' | 'class' | 'width' | 'height'
 
 export type Attributes = Record<Attribute, string>
 
-export type Directives = {
-	[key in string]: unknown
+export type Directives<T = unknown> = {
+	[key in string]: T
 }
 
-export type NomnomlConfig = {
+export type AutoTheme = {
+	foregroundColor: string
+	backgroundColor: string
+}
+
+export type UserConfig = {
 	directives?: Directives
+	autotheme?: boolean
 }
 
 export interface Dependencies {
 	nomnoml: Nomnoml
-	config: NomnomlConfig
+	config: UserConfig
+	autotheme?: AutoTheme[]
 }
 
 export interface DocsifyInstance {

--- a/src/shared/util/auto-theme.test.ts
+++ b/src/shared/util/auto-theme.test.ts
@@ -1,0 +1,101 @@
+import { getThemeStyles } from '.'
+
+describe('nulls', () => {
+	it('should handle empty input', () => {
+		expect(getThemeStyles()).toEqual({})
+		expect(getThemeStyles([])).toEqual({})
+	})
+})
+
+describe('color parsing', () => {
+	it.each`
+		input                       | expected
+		${'fff'}                    | ${false}
+		${'gggggg'}                 | ${false}
+		${'ffffff'}                 | ${true}
+		${'fffffff'}                | ${false}
+		${'000'}                    | ${false}
+		${'000000'}                 | ${true}
+		${'0000000'}                | ${false}
+		${'#fff'}                   | ${false}
+		${'#ffffff'}                | ${true}
+		${'#fffffff'}               | ${false}
+		${'#000'}                   | ${false}
+		${'#000000'}                | ${true}
+		${'#0000000'}               | ${false}
+		${'rgb(0, 0, 0)'}           | ${true}
+		${'rgb(,0, 0, 0)'}          | ${false}
+		${'rgba(0, 0, 0, 0)'}       | ${false}
+		${'rgba(0, 0, 0, 0.9)'}     | ${true}
+		${'rgb(255, 255, 255)'}     | ${true}
+		${'rgb(  0  ,  0  ,  0  )'} | ${true}
+	`('theme should resolve $expected for $input', ({ input, expected }) => {
+		const actual = getThemeStyles([
+			{
+				foregroundColor: input,
+				backgroundColor: input,
+			},
+		])
+		const expectedTheme = expected
+			? expect.objectContaining({
+					stroke: expect.any(String),
+					fill: expect.any(String),
+			  })
+			: {}
+		expect(actual).toEqual(expectedTheme)
+	})
+})
+
+describe('theme variants', () => {
+	it('should resolve a light theme prioritising the current background color', () => {
+		const actual = getThemeStyles([
+			{
+				foregroundColor: '#000000',
+				backgroundColor: '#ffffff',
+			},
+		])
+		const expected = expect.objectContaining({
+			fill: expect.stringContaining('tint'),
+			stroke: expect.any(String),
+		})
+	})
+
+	it('should resolve a dark theme prioritising the current background color', () => {
+		const actual = getThemeStyles([
+			{
+				foregroundColor: '#ffffff',
+				backgroundColor: '#000000',
+			},
+		])
+		const expected = expect.objectContaining({
+			fill: expect.stringContaining('shade'),
+			stroke: expect.any(String),
+		})
+	})
+
+	it('should resolve a light theme falling back to the foreground color', () => {
+		const actual = getThemeStyles([
+			{
+				foregroundColor: '#000000',
+				backgroundColor: 'INVALID',
+			},
+		])
+		const expected = expect.objectContaining({
+			fill: expect.stringContaining('tint'),
+			stroke: expect.any(String),
+		})
+	})
+
+	it('should resolve a dark theme falling back to the foreground color', () => {
+		const actual = getThemeStyles([
+			{
+				foregroundColor: '#ffffff',
+				backgroundColor: 'INVALID',
+			},
+		])
+		const expected = expect.objectContaining({
+			fill: expect.stringContaining('shade'),
+			stroke: expect.any(String),
+		})
+	})
+})

--- a/src/shared/util/auto-theme.ts
+++ b/src/shared/util/auto-theme.ts
@@ -1,0 +1,130 @@
+import { AutoTheme, Directives } from '../types'
+
+type Rgb = [number, number, number]
+
+type Variant = 'light' | 'dark' | false
+
+type ThemeVariant = {
+	variant: Variant
+	autotheme: AutoTheme
+}
+
+const lightness = (rgb: Rgb): number => {
+	const [r, g, b] = rgb.map((n) => n / 255)
+	return (Math.max(r, g, b) + Math.min(r, g, b)) / 2
+}
+
+const RE_COLOR =
+	/^(?:(#?)([a-f\d]{6}))$|^(?:(rgba?)\(((?:\s*\d+\s*)(?:,?\s*\d+\s*){2}(?:,?\s*(?:0\.)?\d+\s*)?))\)$/i
+const RE_MATCH_HEX = /[a-f\d]{2}/g
+const RE_MATCH_NUM = /(?:\d+\.)?\d+/g
+
+const parseColor = (color: string): Rgb | false => {
+	const [, maybeHex, hex, maybeRgb, rgb] = RE_COLOR.exec(color) || []
+	switch (maybeHex ?? maybeRgb) {
+		case '':
+		case '#': {
+			return (hex.match(RE_MATCH_HEX) || []).map((n) =>
+				Number.parseInt(n, 16)
+			) as Rgb
+		}
+		case 'rgb': {
+			return (rgb.match(RE_MATCH_NUM) || []).map(Number) as Rgb
+		}
+		case 'rgba': {
+			const [r, g, b, a] = (rgb.match(RE_MATCH_NUM) || []).map(Number)
+			if (a < 0.9) {
+				// low confidence in predicting "light" vs. "dark" theme
+				// note: Chrome getComputedStyle returns a defaults of
+				//       rgba(0, 0, 0, 0) as the background "white" :/
+				return false
+			}
+			return [r, g, b]
+		}
+		default:
+			return false
+	}
+}
+
+const cssStyleChain = (...styles: string[]): string =>
+	styles
+		.slice()
+		.reverse()
+		.reduce((acc, style) => (!acc ? style : `var(${style}, ${acc})`), '')
+
+const resolveVariant = (autothemes: AutoTheme[]): ThemeVariant | false => {
+	const fromBackground = autothemes
+		.map((theme) => {
+			const rgb = parseColor(theme.backgroundColor)
+			if (!rgb) {
+				return false
+			}
+			return {
+				variant: <Variant>(lightness(rgb) >= 0.5 ? 'light' : 'dark'),
+				autotheme: theme,
+			}
+		})
+		.filter(Boolean)
+		.pop()
+
+	if (fromBackground) {
+		return fromBackground
+	}
+
+	const fromForeground = autothemes
+		.map((theme) => {
+			const rgb = parseColor(theme.foregroundColor)
+			if (!rgb) {
+				return false
+			}
+			return {
+				variant: <Variant>(lightness(rgb) <= 0.5 ? 'light' : 'dark'),
+				autotheme: theme,
+			}
+		})
+		.filter(Boolean)
+		.pop()
+
+	if (fromForeground) {
+		return fromForeground
+	}
+
+	return false
+}
+
+export const getThemeStyles = (autotheme?: AutoTheme[]): Directives<string> => {
+	if (!autotheme || !autotheme.length) {
+		return {}
+	}
+
+	const themeVariant = resolveVariant(autotheme)
+
+	if (!themeVariant) {
+		return {}
+	}
+
+	const {
+		variant,
+		autotheme: { foregroundColor, backgroundColor },
+	} = themeVariant
+
+	return {
+		stroke: cssStyleChain(
+			'--nomnoml-svg-stroke',
+			'--theme-color',
+			foregroundColor
+		),
+		fill: [
+			cssStyleChain(
+				'--nomnoml-svg-fill-1',
+				variant === 'light' ? '--mono-tint2' : '--mono-shade2',
+				backgroundColor
+			),
+			cssStyleChain(
+				'--nomnoml-svg-fill-2',
+				variant === 'light' ? '--mono-tint3' : '--mono-shade3',
+				backgroundColor
+			),
+		].join('; '),
+	}
+}

--- a/src/shared/util/index.ts
+++ b/src/shared/util/index.ts
@@ -1,4 +1,5 @@
 export * from './is'
+export * from './auto-theme'
 export * from './parse-attributes'
 export * from './is-valid-identifier'
 export * from './stringify-attributes'


### PR DESCRIPTION
 - resolves #2

Automatically attempt to match the current page styling - can be diabled by setting `autotheme` to `false` in the config.

Otherwise exposes overridable CSS classes:

```css
:root {
    --nomnoml-svg-stroke: <color>;
    --nomnoml-svg-fill-1: <color>;
    --nomnoml-svg-fill-2: <color>;
}
```